### PR TITLE
Add 4.14.1 packages

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.14.1+flambda+mingw32/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+flambda+mingw32/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.14.1 with flambda activated (mingw32)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/fdopen/opam-repository-mingw/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: [
+  [OCAMLLIB = "%{prefix}%/lib/ocaml"]
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+  [CC = "i686-w64-mingw32-gcc.exe"]
+  [CPP = "i686-w64-mingw32-cpp.exe"]
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-flexdll" "--enable-flambda" "--host=i686-w64-mingw32" "CC=i686-w64-mingw32-gcc" "CPP=i686-w64-mingw32-cpp"]
+  [make "SHELL=/bin/dash" "-j%{jobs}%" "world.opt"]
+]
+install: [
+  [make "SHELL=/bin/dash" "install"]
+  ["dash" "-exc" "echo \"%{lib}%/stublibs\"  >> \"%{lib}%/ocaml/ld.conf\""]
+]
+patches: ["ocaml-4.14.0.patch" "inline-flexdll.patch"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.1.tar.gz"
+  checksum: "sha512=6340e145c7d11a1ee9fa1699fc6a8a6785f14ff9c05dca708cf278194642ec9b7c562d744d8b38e5dab74b88fa3a5760035e214f5f8fab8b233a344b035db8fb"
+}
+extra-source "ocaml-4.14.0.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/2def708d5eb7c8764c7b0804587a57dd/raw/2897d6a477dce97b88cdf8633355a99400d0e083/ocaml-4.14.0.patch"
+  checksum: "sha512=e0619fd60cc9d51434b4b09f6290dd68c308e34b610c01e29e5dbd90b6c19615b736937c6444bd34a56ac363e109ee51ba2893626e18926fc413abe244f37797"
+}
+extra-source "inline-flexdll.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/afe3140904cc975cc9d2e4992e13d547/raw/3d8b647eb196a3174e6c6105881e5d6a4b8fa166/inline-flexdll.patch"
+  checksum: "sha512=1a5abdad64f222d7f6f201cdbc0c568c63892cf46fa587882d105e1c3e6f1ddae5e301460e0d6022ca73edfbe8cbc7baf9310930bafba50aedfe304031dc4496"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+flambda+mingw32c/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+flambda+mingw32c/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.14.1 with flambda activated (mingw32)"
+description: "Sunset compatibility package - the compiler is built from source"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/fdopen/opam-repository-mingw/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: [
+  [OCAMLLIB = "%{prefix}%/lib/ocaml"]
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+  [CC = "i686-w64-mingw32-gcc.exe"]
+  [CPP = "i686-w64-mingw32-cpp.exe"]
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-flexdll" "--enable-flambda" "--host=i686-w64-mingw32" "CC=i686-w64-mingw32-gcc" "CPP=i686-w64-mingw32-cpp"]
+  [make "SHELL=/bin/dash" "-j%{jobs}%" "world.opt"]
+]
+install: [
+  [make "SHELL=/bin/dash" "install"]
+  ["dash" "-exc" "echo \"%{lib}%/stublibs\"  >> \"%{lib}%/ocaml/ld.conf\""]
+]
+patches: ["ocaml-4.14.0.patch" "inline-flexdll.patch"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.1.tar.gz"
+  checksum: "sha512=6340e145c7d11a1ee9fa1699fc6a8a6785f14ff9c05dca708cf278194642ec9b7c562d744d8b38e5dab74b88fa3a5760035e214f5f8fab8b233a344b035db8fb"
+}
+extra-source "ocaml-4.14.0.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/2def708d5eb7c8764c7b0804587a57dd/raw/2897d6a477dce97b88cdf8633355a99400d0e083/ocaml-4.14.0.patch"
+  checksum: "sha512=e0619fd60cc9d51434b4b09f6290dd68c308e34b610c01e29e5dbd90b6c19615b736937c6444bd34a56ac363e109ee51ba2893626e18926fc413abe244f37797"
+}
+extra-source "inline-flexdll.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/afe3140904cc975cc9d2e4992e13d547/raw/3d8b647eb196a3174e6c6105881e5d6a4b8fa166/inline-flexdll.patch"
+  checksum: "sha512=1a5abdad64f222d7f6f201cdbc0c568c63892cf46fa587882d105e1c3e6f1ddae5e301460e0d6022ca73edfbe8cbc7baf9310930bafba50aedfe304031dc4496"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+flambda+mingw64/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+flambda+mingw64/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.14.1 with flambda activated (mingw64)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/fdopen/opam-repository-mingw/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: [
+  [OCAMLLIB = "%{prefix}%/lib/ocaml"]
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+  [CC = "x86_64-w64-mingw32-gcc.exe"]
+  [CPP = "x86_64-w64-mingw32-cpp.exe"]
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-flexdll" "--host=x86_64-w64-mingw32" "--enable-flambda" "CC=x86_64-w64-mingw32-gcc" "CPP=x86_64-w64-mingw32-cpp"]
+  [make "SHELL=/bin/dash" "-j%{jobs}%" "world.opt"]
+]
+install: [
+  [make "SHELL=/bin/dash" "install"]
+  ["dash" "-exc" "echo \"%{lib}%/stublibs\"  >> \"%{lib}%/ocaml/ld.conf\""]
+]
+patches: ["ocaml-4.14.0.patch" "inline-flexdll.patch"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.1.tar.gz"
+  checksum: "sha512=6340e145c7d11a1ee9fa1699fc6a8a6785f14ff9c05dca708cf278194642ec9b7c562d744d8b38e5dab74b88fa3a5760035e214f5f8fab8b233a344b035db8fb"
+}
+extra-source "ocaml-4.14.0.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/2def708d5eb7c8764c7b0804587a57dd/raw/2897d6a477dce97b88cdf8633355a99400d0e083/ocaml-4.14.0.patch"
+  checksum: "sha512=e0619fd60cc9d51434b4b09f6290dd68c308e34b610c01e29e5dbd90b6c19615b736937c6444bd34a56ac363e109ee51ba2893626e18926fc413abe244f37797"
+}
+extra-source "inline-flexdll.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/afe3140904cc975cc9d2e4992e13d547/raw/3d8b647eb196a3174e6c6105881e5d6a4b8fa166/inline-flexdll.patch"
+  checksum: "sha512=1a5abdad64f222d7f6f201cdbc0c568c63892cf46fa587882d105e1c3e6f1ddae5e301460e0d6022ca73edfbe8cbc7baf9310930bafba50aedfe304031dc4496"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+flambda+mingw64c/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+flambda+mingw64c/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.14.1 with flambda activated (mingw64)"
+description: "Sunset compatibility package - the compiler is built from source"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/fdopen/opam-repository-mingw/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: [
+  [OCAMLLIB = "%{prefix}%/lib/ocaml"]
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+  [CC = "x86_64-w64-mingw32-gcc.exe"]
+  [CPP = "x86_64-w64-mingw32-cpp.exe"]
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-flexdll" "--host=x86_64-w64-mingw32" "--enable-flambda" "CC=x86_64-w64-mingw32-gcc" "CPP=x86_64-w64-mingw32-cpp"]
+  [make "SHELL=/bin/dash" "-j%{jobs}%" "world.opt"]
+]
+install: [
+  [make "SHELL=/bin/dash" "install"]
+  ["dash" "-exc" "echo \"%{lib}%/stublibs\"  >> \"%{lib}%/ocaml/ld.conf\""]
+]
+patches: ["ocaml-4.14.0.patch" "inline-flexdll.patch"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.1.tar.gz"
+  checksum: "sha512=6340e145c7d11a1ee9fa1699fc6a8a6785f14ff9c05dca708cf278194642ec9b7c562d744d8b38e5dab74b88fa3a5760035e214f5f8fab8b233a344b035db8fb"
+}
+extra-source "ocaml-4.14.0.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/2def708d5eb7c8764c7b0804587a57dd/raw/2897d6a477dce97b88cdf8633355a99400d0e083/ocaml-4.14.0.patch"
+  checksum: "sha512=e0619fd60cc9d51434b4b09f6290dd68c308e34b610c01e29e5dbd90b6c19615b736937c6444bd34a56ac363e109ee51ba2893626e18926fc413abe244f37797"
+}
+extra-source "inline-flexdll.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/afe3140904cc975cc9d2e4992e13d547/raw/3d8b647eb196a3174e6c6105881e5d6a4b8fa166/inline-flexdll.patch"
+  checksum: "sha512=1a5abdad64f222d7f6f201cdbc0c568c63892cf46fa587882d105e1c3e6f1ddae5e301460e0d6022ca73edfbe8cbc7baf9310930bafba50aedfe304031dc4496"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+mingw32/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+mingw32/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.14.1 (mingw32)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/fdopen/opam-repository-mingw/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: [
+  [OCAMLLIB = "%{prefix}%/lib/ocaml"]
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+  [CC = "i686-w64-mingw32-gcc.exe"]
+  [CPP = "i686-w64-mingw32-cpp.exe"]
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-flexdll" "--host=i686-w64-mingw32" "CC=i686-w64-mingw32-gcc" "CPP=i686-w64-mingw32-cpp"]
+  [make "SHELL=/bin/dash" "-j%{jobs}%" "world.opt"]
+]
+install: [
+  [make "SHELL=/bin/dash" "install"]
+  ["dash" "-exc" "echo \"%{lib}%/stublibs\"  >> \"%{lib}%/ocaml/ld.conf\""]
+]
+patches: ["ocaml-4.14.0.patch" "inline-flexdll.patch"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.1.tar.gz"
+  checksum: "sha512=6340e145c7d11a1ee9fa1699fc6a8a6785f14ff9c05dca708cf278194642ec9b7c562d744d8b38e5dab74b88fa3a5760035e214f5f8fab8b233a344b035db8fb"
+}
+extra-source "ocaml-4.14.0.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/2def708d5eb7c8764c7b0804587a57dd/raw/2897d6a477dce97b88cdf8633355a99400d0e083/ocaml-4.14.0.patch"
+  checksum: "sha512=e0619fd60cc9d51434b4b09f6290dd68c308e34b610c01e29e5dbd90b6c19615b736937c6444bd34a56ac363e109ee51ba2893626e18926fc413abe244f37797"
+}
+extra-source "inline-flexdll.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/afe3140904cc975cc9d2e4992e13d547/raw/3d8b647eb196a3174e6c6105881e5d6a4b8fa166/inline-flexdll.patch"
+  checksum: "sha512=1a5abdad64f222d7f6f201cdbc0c568c63892cf46fa587882d105e1c3e6f1ddae5e301460e0d6022ca73edfbe8cbc7baf9310930bafba50aedfe304031dc4496"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+mingw32c/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+mingw32c/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.14.1 (mingw32)"
+description: "Sunset compatibility package - the compiler is built from source"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/fdopen/opam-repository-mingw/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: [
+  [OCAMLLIB = "%{prefix}%/lib/ocaml"]
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+  [CC = "i686-w64-mingw32-gcc.exe"]
+  [CPP = "i686-w64-mingw32-cpp.exe"]
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-flexdll" "--host=i686-w64-mingw32" "CC=i686-w64-mingw32-gcc" "CPP=i686-w64-mingw32-cpp"]
+  [make "SHELL=/bin/dash" "-j%{jobs}%" "world.opt"]
+]
+install: [
+  [make "SHELL=/bin/dash" "install"]
+  ["dash" "-exc" "echo \"%{lib}%/stublibs\"  >> \"%{lib}%/ocaml/ld.conf\""]
+]
+patches: ["ocaml-4.14.0.patch" "inline-flexdll.patch"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.1.tar.gz"
+  checksum: "sha512=6340e145c7d11a1ee9fa1699fc6a8a6785f14ff9c05dca708cf278194642ec9b7c562d744d8b38e5dab74b88fa3a5760035e214f5f8fab8b233a344b035db8fb"
+}
+extra-source "ocaml-4.14.0.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/2def708d5eb7c8764c7b0804587a57dd/raw/2897d6a477dce97b88cdf8633355a99400d0e083/ocaml-4.14.0.patch"
+  checksum: "sha512=e0619fd60cc9d51434b4b09f6290dd68c308e34b610c01e29e5dbd90b6c19615b736937c6444bd34a56ac363e109ee51ba2893626e18926fc413abe244f37797"
+}
+extra-source "inline-flexdll.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/afe3140904cc975cc9d2e4992e13d547/raw/3d8b647eb196a3174e6c6105881e5d6a4b8fa166/inline-flexdll.patch"
+  checksum: "sha512=1a5abdad64f222d7f6f201cdbc0c568c63892cf46fa587882d105e1c3e6f1ddae5e301460e0d6022ca73edfbe8cbc7baf9310930bafba50aedfe304031dc4496"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+mingw64/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+mingw64/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.14.1 (mingw64)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/fdopen/opam-repository-mingw/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: [
+  [OCAMLLIB = "%{prefix}%/lib/ocaml"]
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+  [CC = "x86_64-w64-mingw32-gcc.exe"]
+  [CPP = "x86_64-w64-mingw32-cpp.exe"]
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-flexdll" "--host=x86_64-w64-mingw32" "CC=x86_64-w64-mingw32-gcc" "CPP=x86_64-w64-mingw32-cpp"]
+  [make "SHELL=/bin/dash" "-j%{jobs}%" "world.opt"]
+]
+install: [
+  [make "SHELL=/bin/dash" "install"]
+  ["dash" "-exc" "echo \"%{lib}%/stublibs\"  >> \"%{lib}%/ocaml/ld.conf\""]
+]
+patches: ["ocaml-4.14.0.patch" "inline-flexdll.patch"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.1.tar.gz"
+  checksum: "sha512=6340e145c7d11a1ee9fa1699fc6a8a6785f14ff9c05dca708cf278194642ec9b7c562d744d8b38e5dab74b88fa3a5760035e214f5f8fab8b233a344b035db8fb"
+}
+extra-source "ocaml-4.14.0.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/2def708d5eb7c8764c7b0804587a57dd/raw/2897d6a477dce97b88cdf8633355a99400d0e083/ocaml-4.14.0.patch"
+  checksum: "sha512=e0619fd60cc9d51434b4b09f6290dd68c308e34b610c01e29e5dbd90b6c19615b736937c6444bd34a56ac363e109ee51ba2893626e18926fc413abe244f37797"
+}
+extra-source "inline-flexdll.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/afe3140904cc975cc9d2e4992e13d547/raw/3d8b647eb196a3174e6c6105881e5d6a4b8fa166/inline-flexdll.patch"
+  checksum: "sha512=1a5abdad64f222d7f6f201cdbc0c568c63892cf46fa587882d105e1c3e6f1ddae5e301460e0d6022ca73edfbe8cbc7baf9310930bafba50aedfe304031dc4496"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+mingw64c/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+mingw64c/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.14.1 (mingw64)"
+description: "Sunset compatibility package - the compiler is built from source"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/fdopen/opam-repository-mingw/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: [
+  [OCAMLLIB = "%{prefix}%/lib/ocaml"]
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+  [CC = "x86_64-w64-mingw32-gcc.exe"]
+  [CPP = "x86_64-w64-mingw32-cpp.exe"]
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-flexdll" "--host=x86_64-w64-mingw32" "CC=x86_64-w64-mingw32-gcc" "CPP=x86_64-w64-mingw32-cpp"]
+  [make "SHELL=/bin/dash" "-j%{jobs}%" "world.opt"]
+]
+install: [
+  [make "SHELL=/bin/dash" "install"]
+  ["dash" "-exc" "echo \"%{lib}%/stublibs\"  >> \"%{lib}%/ocaml/ld.conf\""]
+]
+patches: ["ocaml-4.14.0.patch" "inline-flexdll.patch"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.1.tar.gz"
+  checksum: "sha512=6340e145c7d11a1ee9fa1699fc6a8a6785f14ff9c05dca708cf278194642ec9b7c562d744d8b38e5dab74b88fa3a5760035e214f5f8fab8b233a344b035db8fb"
+}
+extra-source "ocaml-4.14.0.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/2def708d5eb7c8764c7b0804587a57dd/raw/2897d6a477dce97b88cdf8633355a99400d0e083/ocaml-4.14.0.patch"
+  checksum: "sha512=e0619fd60cc9d51434b4b09f6290dd68c308e34b610c01e29e5dbd90b6c19615b736937c6444bd34a56ac363e109ee51ba2893626e18926fc413abe244f37797"
+}
+extra-source "inline-flexdll.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/afe3140904cc975cc9d2e4992e13d547/raw/3d8b647eb196a3174e6c6105881e5d6a4b8fa166/inline-flexdll.patch"
+  checksum: "sha512=1a5abdad64f222d7f6f201cdbc0c568c63892cf46fa587882d105e1c3e6f1ddae5e301460e0d6022ca73edfbe8cbc7baf9310930bafba50aedfe304031dc4496"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+msvc32/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+msvc32/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.14.1 (msvc32)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/fdopen/opam-repository-mingw/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: [
+  [OCAMLLIB = "%{prefix}%/lib/ocaml"]
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+  [CC = "cl.exe"]
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-flexdll" "--host=i686-pc-windows"]
+  [make "SHELL=/bin/dash" "-j%{jobs}%" "world.opt"]
+]
+install: [
+  [make "SHELL=/bin/dash" "install"]
+  ["dash" "-exc" "echo \"%{lib}%/stublibs\"  >> \"%{lib}%/ocaml/ld.conf\""]
+]
+patches: ["ocaml-4.14.0.patch" "inline-flexdll.patch"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.1.tar.gz"
+  checksum: "sha512=6340e145c7d11a1ee9fa1699fc6a8a6785f14ff9c05dca708cf278194642ec9b7c562d744d8b38e5dab74b88fa3a5760035e214f5f8fab8b233a344b035db8fb"
+}
+extra-source "ocaml-4.14.0.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/2def708d5eb7c8764c7b0804587a57dd/raw/2897d6a477dce97b88cdf8633355a99400d0e083/ocaml-4.14.0.patch"
+  checksum: "sha512=e0619fd60cc9d51434b4b09f6290dd68c308e34b610c01e29e5dbd90b6c19615b736937c6444bd34a56ac363e109ee51ba2893626e18926fc413abe244f37797"
+}
+extra-source "inline-flexdll.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/afe3140904cc975cc9d2e4992e13d547/raw/3d8b647eb196a3174e6c6105881e5d6a4b8fa166/inline-flexdll.patch"
+  checksum: "sha512=1a5abdad64f222d7f6f201cdbc0c568c63892cf46fa587882d105e1c3e6f1ddae5e301460e0d6022ca73edfbe8cbc7baf9310930bafba50aedfe304031dc4496"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+msvc32c/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+msvc32c/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.14.1 (msvc32)"
+description: "Sunset compatibility package - the compiler is built from source"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/fdopen/opam-repository-mingw/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: [
+  [OCAMLLIB = "%{prefix}%/lib/ocaml"]
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+  [CC = "cl.exe"]
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-flexdll" "--host=i686-pc-windows"]
+  [make "SHELL=/bin/dash" "-j%{jobs}%" "world.opt"]
+]
+install: [
+  [make "SHELL=/bin/dash" "install"]
+  ["dash" "-exc" "echo \"%{lib}%/stublibs\"  >> \"%{lib}%/ocaml/ld.conf\""]
+]
+patches: ["ocaml-4.14.0.patch" "inline-flexdll.patch"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.1.tar.gz"
+  checksum: "sha512=6340e145c7d11a1ee9fa1699fc6a8a6785f14ff9c05dca708cf278194642ec9b7c562d744d8b38e5dab74b88fa3a5760035e214f5f8fab8b233a344b035db8fb"
+}
+extra-source "ocaml-4.14.0.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/2def708d5eb7c8764c7b0804587a57dd/raw/2897d6a477dce97b88cdf8633355a99400d0e083/ocaml-4.14.0.patch"
+  checksum: "sha512=e0619fd60cc9d51434b4b09f6290dd68c308e34b610c01e29e5dbd90b6c19615b736937c6444bd34a56ac363e109ee51ba2893626e18926fc413abe244f37797"
+}
+extra-source "inline-flexdll.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/afe3140904cc975cc9d2e4992e13d547/raw/3d8b647eb196a3174e6c6105881e5d6a4b8fa166/inline-flexdll.patch"
+  checksum: "sha512=1a5abdad64f222d7f6f201cdbc0c568c63892cf46fa587882d105e1c3e6f1ddae5e301460e0d6022ca73edfbe8cbc7baf9310930bafba50aedfe304031dc4496"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+msvc64/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+msvc64/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.14.1 (msvc64)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/fdopen/opam-repository-mingw/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: [
+  [OCAMLLIB = "%{prefix}%/lib/ocaml"]
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+  [CC = "cl.exe"]
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-flexdll" "--host=x86_64-pc-windows"]
+  [make "SHELL=/bin/dash" "-j%{jobs}%" "world.opt"]
+]
+install: [
+  [make "SHELL=/bin/dash" "install"]
+  ["dash" "-exc" "echo \"%{lib}%/stublibs\"  >> \"%{lib}%/ocaml/ld.conf\""]
+]
+patches: ["ocaml-4.14.0.patch" "inline-flexdll.patch"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.1.tar.gz"
+  checksum: "sha512=6340e145c7d11a1ee9fa1699fc6a8a6785f14ff9c05dca708cf278194642ec9b7c562d744d8b38e5dab74b88fa3a5760035e214f5f8fab8b233a344b035db8fb"
+}
+extra-source "ocaml-4.14.0.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/2def708d5eb7c8764c7b0804587a57dd/raw/2897d6a477dce97b88cdf8633355a99400d0e083/ocaml-4.14.0.patch"
+  checksum: "sha512=e0619fd60cc9d51434b4b09f6290dd68c308e34b610c01e29e5dbd90b6c19615b736937c6444bd34a56ac363e109ee51ba2893626e18926fc413abe244f37797"
+}
+extra-source "inline-flexdll.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/afe3140904cc975cc9d2e4992e13d547/raw/3d8b647eb196a3174e6c6105881e5d6a4b8fa166/inline-flexdll.patch"
+  checksum: "sha512=1a5abdad64f222d7f6f201cdbc0c568c63892cf46fa587882d105e1c3e6f1ddae5e301460e0d6022ca73edfbe8cbc7baf9310930bafba50aedfe304031dc4496"
+}

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+msvc64c/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+msvc64c/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.14.1 (msvc64)"
+description: "Sunset compatibility package - the compiler is built from source"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/fdopen/opam-repository-mingw/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: [
+  [OCAMLLIB = "%{prefix}%/lib/ocaml"]
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+  [CC = "cl.exe"]
+]
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-flexdll" "--host=x86_64-pc-windows"]
+  [make "SHELL=/bin/dash" "-j%{jobs}%" "world.opt"]
+]
+install: [
+  [make "SHELL=/bin/dash" "install"]
+  ["dash" "-exc" "echo \"%{lib}%/stublibs\"  >> \"%{lib}%/ocaml/ld.conf\""]
+]
+patches: ["ocaml-4.14.0.patch" "inline-flexdll.patch"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/refs/tags/4.14.1.tar.gz"
+  checksum: "sha512=6340e145c7d11a1ee9fa1699fc6a8a6785f14ff9c05dca708cf278194642ec9b7c562d744d8b38e5dab74b88fa3a5760035e214f5f8fab8b233a344b035db8fb"
+}
+extra-source "ocaml-4.14.0.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/2def708d5eb7c8764c7b0804587a57dd/raw/2897d6a477dce97b88cdf8633355a99400d0e083/ocaml-4.14.0.patch"
+  checksum: "sha512=e0619fd60cc9d51434b4b09f6290dd68c308e34b610c01e29e5dbd90b6c19615b736937c6444bd34a56ac363e109ee51ba2893626e18926fc413abe244f37797"
+}
+extra-source "inline-flexdll.patch" {
+  src:
+    "https://gist.githubusercontent.com/fdopen/afe3140904cc975cc9d2e4992e13d547/raw/3d8b647eb196a3174e6c6105881e5d6a4b8fa166/inline-flexdll.patch"
+  checksum: "sha512=1a5abdad64f222d7f6f201cdbc0c568c63892cf46fa587882d105e1c3e6f1ddae5e301460e0d6022ca73edfbe8cbc7baf9310930bafba50aedfe304031dc4496"
+}


### PR DESCRIPTION
Clones the 4.14.0 packages with 4.14.1 versions (the patches all apply without alteration).

There are no precompiled variants - the second commit simply clones the source-building ones to ensure setup-ocaml, etc. can still install `+mingw64c` without failing. The impact is a slower set-up stage for the CI run, GHA caching takes over from then anyway.