### PR TITLE
Add: cmdliner.1.2.0

### DIFF
--- a/packages/cmdliner/cmdliner.1.2.0/opam
+++ b/packages/cmdliner/cmdliner.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Declarative definition of command line interfaces for OCaml"
+description: """\
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+
+Home page: http://erratique.ch/software/cmdliner"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The cmdliner programmers"
+license: "ISC"
+tags: ["cli" "system" "declarative" "org:erratique"]
+homepage: "https://erratique.ch/software/cmdliner"
+doc: "https://erratique.ch/software/cmdliner/doc"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+]
+build: [make "all" "PREFIX=%{prefix}%"]
+install: [
+  [make "install" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%"]
+  [make "install-doc" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%"]
+]
+dev-repo: "git+https://erratique.ch/repos/cmdliner.git"
+url {
+  src: "https://erratique.ch/software/cmdliner/releases/cmdliner-1.2.0.tbz"
+  checksum:
+    "sha512=6fcd6a59a6fbc6986b1aecdc3e4ce7a0dc43c65a16b427d6caa5504b10b51384f6b0bc703af646b09f5f1caeb6827b37d4480ce350ca8006204c850785f2810b"
+}


### PR DESCRIPTION
This cherry-picks 0caa44709afd31171c66f84ff1501cf1971b05f3.

I need uptodate packages in this repository because https://github.com/ocaml/setup-ocaml uses it has the only repository for the windows runner. Is this how this repository is intended to be used ?

I noticed that other packages were cherry-picked in this way.