### PR TITLE
Update ocamlformat dependency on odoc-parser

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.24.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.24.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml-version" {>= "3.3.0" & < "3.6.0"}
   "ocamlformat-rpc-lib" {with-test & = version}
   "ocp-indent"
-  "odoc-parser" {>= "2.0.0" & < "3.0.0"}
+  "odoc-parser" {>= "2.0.0" & < "2.3.0"}
   "re" {>= "1.7.2"}
   "stdio"
   "uuseg" {>= "10.0.0"}


### PR DESCRIPTION
Odoc-parser 2.3.0 has introduced some breaking changes...